### PR TITLE
Portable Configuration

### DIFF
--- a/subselect/main.lua
+++ b/subselect/main.lua
@@ -5,6 +5,7 @@ options = {}
 options.down_dir = ""
 options.sub_language = "eng"
 options.subselect_path = utils.join_path(mp.get_script_directory(), "subselect.py")
+options.python = "python"
 
 if package.config:sub(1,1) == "/" then
    ops = "unix"
@@ -66,7 +67,7 @@ function get_python_binary()
    python_error = ""
    python_version = mp.command_native({
       name = "subprocess",
-      args = { "python", "--version"},
+      args = { options.python, "--version"},
       capture_stdout = true
    })
 
@@ -74,17 +75,17 @@ function get_python_binary()
       python_error = "python not found"
    else
       if python_version.stdout:find("3%.") ~= nil then
-         python = "python"
+         python = options.python
       else
          python_version = mp.command_native({
             name = "subprocess",
-            args = { "python3", "--version" }
+            args = { options.python.."3", "--version" }
          })
          
          if python_version.error_string ~= "" then
             python_error = "python3 not installed"
          else
-            python = "python3"
+            python = options.python.."3"
          end
       end
    end


### PR DESCRIPTION
Portable Configuration
- Changes made to allow usage of script with portable python (and mpv).

To create a working portable python package follow these links.
- https://github.com/indygreg/python-build-standalone/
Install subliminal in the package using:
- python -m pip install subliminal
Add python location to subselect.conf as python= 
Path can be relative from the mpv directory or absolute.
For ex.
- python=python\\python
This is for windows where python binaries are located under root directory.
Directory structure for the above ex. is mpv_portable\python\python.exe